### PR TITLE
Allow for empty value in quick-edit select field

### DIFF
--- a/index.php
+++ b/index.php
@@ -331,6 +331,9 @@ class ACFToQuickEdit {
 						switch ($field['type']) {
 							case 'select':
 								?><select class="acf-quick-edit" data-acf-field-key="<?php echo $field['key'] ?>" name="<?php echo $this->post_field_prefix . $column; ?>"><?php
+									if ( $field['allow_null'] ) {
+										echo '<option value="">' . '- ' . __( 'Select', 'acf' ) . ' -';
+									}
 									foreach($field['choices'] as $name => $label) {
 										echo '<option value="' . $name . '">' . $label;
 									}


### PR DESCRIPTION
If allow_null is set to true, the `<select>` field should show an empty first option, just like ACF itself does.