### PR TITLE
add apply_filters function

### DIFF
--- a/index.php
+++ b/index.php
@@ -177,13 +177,9 @@ class ACFToQuickEdit {
 		$post_type = isset($_REQUEST['post_type']) ? $_REQUEST['post_type'] : ( ! empty( $typenow ) ? $typenow : 'post' );
 		if ( ! $post_type && $pagenow == 'upload.php' ) {
 			$post_type = 'attachment';
-			$field_groups = acf_get_field_groups( array(
-	 			'attachment' => 'all|image',
-			) );
+			$field_groups = acf_get_field_groups( apply_filters( 'acf_quick_edit_fields_group_filter', array( 'attachment' => 'all|image' ) ) );
 		} else {
-			$field_groups = acf_get_field_groups( array(
-				'post_type' => $post_type,
-			) );
+			$field_groups = acf_get_field_groups( apply_filters( 'acf_quick_edit_fields_group_filter', array( 'post_type' => $post_type ) ) );
 		}
 
 		foreach ( $field_groups as $field_group ) {


### PR DESCRIPTION
I ran into the issue that an acf field group had multiple display rules,
like:

display filed group when it is a type of page AND
if it is a sub page of some page id

with the standard $args array of 'post_type' => 'page' the acf location
rule match would always fail as the rule check of parent_page would
always return false. and it would not display the acf field in the page
table column

with the apply_filters() i could hook into this and return an $ args
like:

array(
'post_type' => 'page',
'post_parent' => 110,  (the page id set in the acf field group display
ruke)
'post_id' => 115 ( a page id which is a child of the parent page id
)

now the acf location rule match will return true for the field group and
the acf field will get displayed in the page table column.

also ... thanks a lot for that nice piece of code. exactly what i was
looking for ;)