### PR TITLE
Added composer.json to make compatable with composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .svnignore
 .sass-cache
 node_modules/
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "mcguffin/acf-quick-edit-fields",
     "description": "WordPress Plugin implementing Column Displaying, QuickEdit and BulkEdit for Advanced Custom Fields (ACF)",
+    "type": "wordpress-plugin",
     "authors": [
         {
             "name": "Jörn Lund",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "mcguffin/acf-quick-edit-fields",
+    "description": "WordPress Plugin implementing Column Displaying, QuickEdit and BulkEdit for Advanced Custom Fields (ACF)",
+    "authors": [
+        {
+            "name": "Jörn Lund",
+            "email": "joern@flyingletters.com"
+        }
+    ],
+    "minimum-stability": "dev",
+    "require": {}
+}


### PR DESCRIPTION
Allows this plugin to be required via composer. In the composer.json file: 

```json
{
    "repositories": [
      {
	  "type" : "git",
	  "url" : "https://github.com/mcguffin/acf-quick-edit-fields.git" 
      },
    ],
    "extra": {
	"installer-paths": {
          "wp-content/plugins/{$name}/": [
            "wpackagist-plugin/*",
            "type:wordpress-plugin"
          ]
       }
    },
    "require": {
	"mcguffin/acf-quick-edit-fields": "*"
    },

}
