### PR TITLE
Check for non-empty string in TrueFalseField

### DIFF
--- a/include/ACFQuickEdit/Fields/TrueFalseField.php
+++ b/include/ACFQuickEdit/Fields/TrueFalseField.php
@@ -31,7 +31,7 @@ class TrueFalseField extends Field {
 		$choices = $this->get_choices();
 		$value = get_field( $this->acf_field['key'], $object_id, false );
 
-		if ( is_string( $value ) ) {
+		if ( is_string( $value ) && ! empty( $value ) ) {
 			return $choices[ $value ];
 		}
 


### PR DESCRIPTION
Addresses #195 to check for an empty $value before trying to access an array key that might not exist, triggering a PHP warning.