### PR TITLE
Cast value to float before rounding with step

### DIFF
--- a/include/ACFQuickEdit/Fields/Traits/BulkOperationNumeric.php
+++ b/include/ACFQuickEdit/Fields/Traits/BulkOperationNumeric.php
@@ -56,7 +56,7 @@ trait BulkOperationNumeric {
 			$value = min( $this->acf_field['max'], $value );
 		}
 		if ( $this->acf_field['step'] ) {
-			$value = round( $value / $this->acf_field['step'] ) * $this->acf_field['step'];
+			$value = round( (float) $value / $this->acf_field['step'] ) * $this->acf_field['step'];
 		}
 		return $value;
 	}


### PR DESCRIPTION
Addresses #198 in cases where `$value` is an empty string on PHP 7.4+